### PR TITLE
Add next/prev navigation links to per-verse pages

### DIFF
--- a/gen/gen.py
+++ b/gen/gen.py
@@ -93,11 +93,15 @@ for (BookId, Title) in con.execute('SELECT * FROM Book'):
 
 print('Making page for Knums')
 # A page for each Knum.
-for knum in knums:
+for i, knum in enumerate(knums):
     # SELECT MorselId FROM Morsel WHERE Knum=?
     morsel_ids = con.execute('SELECT MorselId FROM Morsel WHERE Knum = ? ORDER BY BookId', [knum])
     morsels_for_knum = [morsels_for_id[morsel_id] for (morsel_id,) in morsel_ids]
+    prev_knum = knums[i - 1] if i > 0 else None
+    next_knum = knums[i + 1] if i < len(knums) - 1 else None
     open(f'web/{knum}.html', 'w').write(env.get_template('gen/knum.html').render(
         Knum = knum,
-        morsels = morsels_for_knum
+        morsels = morsels_for_knum,
+        prev_knum = prev_knum,
+        next_knum = next_knum
     ))

--- a/gen/knum.html
+++ b/gen/knum.html
@@ -36,10 +36,26 @@
 
 <body>
     <div class="container">
+        <div class="navigation">
+            {% if prev_knum %}
+            <a href="{{ prev_knum }}.html">Previous</a>
+            {% endif %}
+            {% if next_knum %}
+            <a href="{{ next_knum }}.html">Next</a>
+            {% endif %}
+        </div>
         {% for morsel in morsels|nonempty %}
         {% set linkBook = True %}
         {% include "gen/morsel.html" %}
         {% endfor %}
+        <div class="navigation">
+            {% if prev_knum %}
+            <a href="{{ prev_knum }}.html">Previous</a>
+            {% endif %}
+            {% if next_knum %}
+            <a href="{{ next_knum }}.html">Next</a>
+            {% endif %}
+        </div>
     </div>
 </body>
 


### PR DESCRIPTION
Related to #16

Add next/prev navigation links to per-verse pages

* Modify `gen/knum.html` to include next-verse and prev-verse navigation links at the top and bottom of the page.
* Add logic to `gen/gen.py` to compute and pass the next and previous Knums to the template.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shreevatsa/bhartrhari/issues/16?shareId=2541e075-8655-4a63-bf3d-bb38e3d78633).